### PR TITLE
db에서 동더히로바 데이터를 가져와 서열표 색칠하는 기능 일부 수정

### DIFF
--- a/src/lib/components/page/diffchart/Diffchart.svelte
+++ b/src/lib/components/page/diffchart/Diffchart.svelte
@@ -13,91 +13,12 @@
             return null;
         }
     }
-
-    function parseSongScoreDonderData(data: UserDonderData): SongScore[] | null{
-        const result : SongScore[] = [];
-        try {
-            for(let scoreData of data.clearData) {
-                const details : Partial<Record<DifficultyType, SongScoreDetail>> = parseDetail(scoreData.difficulty);
-                const score : SongScore = {
-                    title : scoreData.title,
-                    songNo : scoreData.songNo,
-                    details : details,
-                };
-                result.push(score);
-            }
-            return result;
-        } catch (err) {
-            if (browser) {
-                console.log(err);
-            }
-            return null;
-        }
-    }
-
-    function parseDetail(data: Partial<Record<Difficulty, Clear>>) : Partial<Record<DifficultyType, SongScoreDetail>> {
-        const result : Partial<Record<DifficultyType, SongScoreDetail>> = {}; 
-        
-        if(data.ura !== null && data.ura !== undefined) {
-            result.oni_ura = {
-                crown: crowntoCrownType(data.ura.crown),
-                badge: badgetoBadgeType(data.ura.badge),
-            }
-        }
-
-        if(data.oni !== null && data.oni !== undefined) {
-            result.oni = {
-                crown: crowntoCrownType(data.oni.crown),
-                badge: badgetoBadgeType(data.oni.badge),
-            }
-        }
-
-        return result;
-    }
-
-    function crowntoCrownType (crown : string | null) : CrownType  {
-        switch (crown) {
-            case 'silver' : 
-                return "silver";
-            case 'gold' :
-                return "gold";
-            case 'donderfull' :
-                return "donderfull";
-        }
-
-        return "none";
-    }
-
-    function badgetoBadgeType (badge : string | null) : BadgeType  {
-        switch (badge) {
-            case 'rainbow' : 
-                return 8;
-            case 'purple' :
-                return 7;
-            case 'pink' :
-                return 6;
-            case 'gold' :
-                return 5;
-            case 'silver' :
-                return 4;
-            case 'bronze' :
-                return 3;
-            case 'white' :
-                return 2;
-        }
-        
-        return 0;
-    }
 </script>
 
 <script lang="ts">
     import type {
-        BadgeType,
-        CrownType,
         DiffChart,
-        DifficultyType,
         SongScore,
-        SongScoreDetail,
     } from "$lib/module/common/diffchart/types";
     import DiffchartName from "./DiffchartName.svelte";
     import DiffchartSection from "./DiffchartSection.svelte";
@@ -107,12 +28,10 @@
     import html2canvas from "html2canvas";
     import type { SongDataPickedForDiffchart } from "$lib/module/common/diffchart/types";
     import { getI18N, getLang } from "$lib/module/common/i18n/i18n";
-    import type { UserDonderData } from "$lib/module/common/user/types";
-    import type { Clear, Difficulty } from "node-hiroba/types";
 
     export let diffChart: DiffChart;
     export let songs: SongDataPickedForDiffchart[];
-    export let donderData: UserDonderData | null;
+    export let donderData: SongScore[] | null;
     export let color: string | undefined = diffChart.color;
     export let backgroundColor: string | undefined = diffChart.backgroundColor;
     export let downloadImage: (() => Promise<void>) | null = null;
@@ -139,12 +58,11 @@
         };
     });
 
-    let userScoreDataJSON: string = ''; // 확장 프로그램
-    let userScoreDataServer: UserDonderData | null = donderData; // 서버 프로그램
-    $: userScoreData = (userScoreDataServer !== null) ? parseSongScoreDonderData(userScoreDataServer) : parseSongScoreJSON(userScoreDataJSON);
+    let userScoreDataJSON: string = ""; // 확장 프로그램
+    $: userScoreData = donderData ?? parseSongScoreJSON(userScoreDataJSON);
 
     const lang = getLang();
-    $: i18n = getI18N('component', $lang).Diffchart;
+    $: i18n = getI18N("component", $lang).Diffchart;
 </script>
 
 <input

--- a/src/lib/module/common/user/user.server.ts
+++ b/src/lib/module/common/user/user.server.ts
@@ -1,8 +1,7 @@
 import { fetchMeasures, getRating } from "@taiko-wiki/taiko-rating";
 import type { UserClearData, UserData, UserDonderData, UserScoreData } from "./types";
 import { defineDBHandler } from "@yowza/db-handler";
-import type { CardData } from "node-hiroba/types";
-//@ts-expect-error
+import type { CardData, ClearData } from "node-hiroba/types";
 import groupBy from "object.groupby";
 
 export const userDBController = {
@@ -210,6 +209,21 @@ export const userDonderDBController = {
             data.ratingHistory = JSON.parse(data.ratingHistory);
 
             return data as UserDonderData;
+        }
+    }),
+
+    /**
+     * get clear data
+     */
+    getClearData: defineDBHandler<[string], ClearData[]>((UUID) => {
+        return async (run) => {
+            const result = await run("SELECT `clearData` FROM `user/donder_data` WHERE `UUID` = ?", [UUID]);
+
+            if(result.length === 0){
+                return null;
+            }
+
+            return JSON.parse(result[0].clearData)
         }
     })
 }

--- a/src/routes/(main)/diffchart/(dedicated diffchart)/clear/[level]/+page.server.ts
+++ b/src/routes/(main)/diffchart/(dedicated diffchart)/clear/[level]/+page.server.ts
@@ -1,5 +1,4 @@
 import { diffchartDBController } from "$lib/module/common/diffchart/diffchart.server";
-import { userDonderDBController } from "$lib/module/common/user/user.server";
 import { songDBController } from "$lib/module/common/song/song.server";
 import type { SongDataPickedForDiffchart } from "$lib/module/common/diffchart/types";
 import { error } from "@sveltejs/kit";
@@ -23,15 +22,9 @@ export async function load({ params, locals }) {
         })
     })
     const songSearchResult = await songDBController.getSongsColumnsBySongNo(songNos, ["genre", "songNo", "title", "titleKo", "aliasKo"]) as SongDataPickedForDiffchart[]
-    
-    let donderDataResult = null;
-    if(locals.userData !== null) {
-        donderDataResult = await userDonderDBController.getData(locals.userData.UUID);
-    }
 
     return {
         diffChart,
-        songs: songSearchResult,
-        donderData : donderDataResult,
+        songs: songSearchResult
     }
 }

--- a/src/routes/(main)/diffchart/+layout.server.ts
+++ b/src/routes/(main)/diffchart/+layout.server.ts
@@ -6,14 +6,13 @@ import type {
     SongScore,
     SongScoreDetail,
 } from "$lib/module/common/diffchart/types";
-import { type UserDonderData } from '$lib/module/common/user/types.js';
-import type { Clear, Difficulty } from "node-hiroba/types";
+import type { Clear, ClearData, Difficulty } from "node-hiroba/types";
 
 
 export async function load({ locals }) {
     let donderDataResult = null;
     if (locals.userData !== null) {
-        donderDataResult = await userDonderDBController.getData(locals.userData.UUID);
+        donderDataResult = await userDonderDBController.getClearData(locals.userData.UUID);
         if(donderDataResult){
             donderDataResult = parseSongScoreDonderData(donderDataResult);
         }
@@ -24,19 +23,17 @@ export async function load({ locals }) {
     }
 }
 
-function parseSongScoreDonderData(data: UserDonderData): SongScore[] | null {
-    const result: SongScore[] = [];
+function parseSongScoreDonderData(clearData: ClearData[]): SongScore[] | null {
     try {
-        for (let scoreData of data.clearData) {
-            const details: Partial<Record<DifficultyType, SongScoreDetail>> = parseDetail(scoreData.difficulty);
+        return clearData.map(c => {
+            const details: Partial<Record<DifficultyType, SongScoreDetail>> = parseDetail(c.difficulty);
             const score: SongScore = {
-                title: scoreData.title,
-                songNo: scoreData.songNo,
-                details: details,
+                title: c.title,
+                songNo: c.songNo,
+                details
             };
-            result.push(score);
-        }
-        return result;
+            return score;
+        })
     } catch (err) {
         console.warn(err);
         return null;

--- a/src/routes/(main)/diffchart/+layout.server.ts
+++ b/src/routes/(main)/diffchart/+layout.server.ts
@@ -1,0 +1,98 @@
+import { userDonderDBController } from '$lib/module/common/user/user.server.js';
+import type {
+    BadgeType,
+    CrownType,
+    DifficultyType,
+    SongScore,
+    SongScoreDetail,
+} from "$lib/module/common/diffchart/types";
+import { type UserDonderData } from '$lib/module/common/user/types.js';
+import type { Clear, Difficulty } from "node-hiroba/types";
+
+
+export async function load({ locals }) {
+    let donderDataResult = null;
+    if (locals.userData !== null) {
+        donderDataResult = await userDonderDBController.getData(locals.userData.UUID);
+        if(donderDataResult){
+            donderDataResult = parseSongScoreDonderData(donderDataResult);
+        }
+    }
+
+    return {
+        donderData: donderDataResult
+    }
+}
+
+function parseSongScoreDonderData(data: UserDonderData): SongScore[] | null {
+    const result: SongScore[] = [];
+    try {
+        for (let scoreData of data.clearData) {
+            const details: Partial<Record<DifficultyType, SongScoreDetail>> = parseDetail(scoreData.difficulty);
+            const score: SongScore = {
+                title: scoreData.title,
+                songNo: scoreData.songNo,
+                details: details,
+            };
+            result.push(score);
+        }
+        return result;
+    } catch (err) {
+        console.warn(err);
+        return null;
+    }
+}
+
+function parseDetail(data: Partial<Record<Difficulty, Clear>>): Partial<Record<DifficultyType, SongScoreDetail>> {
+    const result: Partial<Record<DifficultyType, SongScoreDetail>> = {};
+
+    if (data.ura !== null && data.ura !== undefined) {
+        result.oni_ura = {
+            crown: crowntoCrownType(data.ura.crown),
+            badge: badgetoBadgeType(data.ura.badge),
+        }
+    }
+
+    if (data.oni !== null && data.oni !== undefined) {
+        result.oni = {
+            crown: crowntoCrownType(data.oni.crown),
+            badge: badgetoBadgeType(data.oni.badge),
+        }
+    }
+
+    return result;
+}
+
+function crowntoCrownType(crown: string | null): CrownType {
+    switch (crown) {
+        case 'silver':
+            return "silver";
+        case 'gold':
+            return "gold";
+        case 'donderfull':
+            return "donderfull";
+    }
+
+    return "none";
+}
+
+function badgetoBadgeType(badge: string | null): BadgeType {
+    switch (badge) {
+        case 'rainbow':
+            return 8;
+        case 'purple':
+            return 7;
+        case 'pink':
+            return 6;
+        case 'gold':
+            return 5;
+        case 'silver':
+            return 4;
+        case 'bronze':
+            return 3;
+        case 'white':
+            return 2;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
- /src/routes/diffchart/layout.server.ts에서 유저의 동더히로바 클리어 데이터를 가져오도록 변경
- /src/routes/diffchart/layout.server.ts에서 클리어 데이터를 서열표에서 사용하는 형식으로 변경하는 함수를 사용하도록 변경
- `userDonderDBController`에 `getClearData` 메소드를 추가하여 클리어 데이터만 가져오도록 변경