### PR TITLE
feat: show song data according to difficulty in search params

### DIFF
--- a/src/lib/components/page/dani/DaniSong.svelte
+++ b/src/lib/components/page/dani/DaniSong.svelte
@@ -37,7 +37,7 @@
 <a
     class="container"
     style={`background:${getGenreColors(genre)};`}
-    href={`/song/${song.songNo}`}
+    href={`/song/${song.songNo}?diff=${song.difficulty}`}
 >
     <div class="container2" data-theme={$theme}>
         <div class="title">

--- a/src/lib/components/page/diffchart/DiffchartSongMobile.svelte
+++ b/src/lib/components/page/diffchart/DiffchartSongMobile.svelte
@@ -17,7 +17,7 @@
 
 <a
     class="container"
-    href={`/song/${song.songNo}`}
+    href={`/song/${song.songNo}?diff=${song.difficulty}`}
     data-theme={theme}
     data-crown={userScore?.crown || ""}
 >

--- a/src/lib/components/page/diffchart/DiffchartSongPc.svelte
+++ b/src/lib/components/page/diffchart/DiffchartSongPc.svelte
@@ -81,7 +81,7 @@
 
 <a
     class="container"
-    href={`/song/${song.songNo}`}
+    href={`/song/${song.songNo}?diff=${song.difficulty}`}
     data-theme={theme}
     data-crown={userScore?.crown || ""}
 >

--- a/src/lib/components/page/song/[songNo]/CourseContainer.svelte
+++ b/src/lib/components/page/song/[songNo]/CourseContainer.svelte
@@ -6,7 +6,7 @@
     import { getTheme } from "$lib/module/layout/theme";
     import FumenDisplay from "./FumenDisplay.svelte";
     import { page } from "$app/stores";
-    import { goto } from "$app/navigation";
+    import { replaceState } from "$app/navigation";
 
     export let courses: SongData["courses"];
     export let selectedDifficulty: Difficulty = "oni";
@@ -26,10 +26,10 @@
                     class="difficulty"
                     class:selected={selectedDifficulty === difficulty}
                     role="presentation"
-                    on:click={async () => {
+                    on:click={() => {
                         selectedDifficulty = difficulty;
                         $page.url.searchParams.set('diff', difficulty);
-                        await goto($page.url, { replaceState: true });
+                        replaceState($page.url, $page.state);
                     }}
                     style={`background-color:${color.difficulty[difficulty]};`}
                 >

--- a/src/lib/components/page/song/[songNo]/CourseContainer.svelte
+++ b/src/lib/components/page/song/[songNo]/CourseContainer.svelte
@@ -5,12 +5,13 @@
     import { getIsMobile } from "$lib/module/layout/isMobile";
     import { getTheme } from "$lib/module/layout/theme";
     import FumenDisplay from "./FumenDisplay.svelte";
+    import { page } from "$app/stores";
+    import { goto } from "$app/navigation";
 
     export let courses: SongData["courses"];
+    export let selectedDifficulty: Difficulty = "oni";
 
     let difficulties: Difficulty[] = ["easy", "normal", "hard", "oni", "ura"];
-
-    let selectedDifficulty: Difficulty = "oni";
 
     const isMobile = getIsMobile();
 
@@ -25,8 +26,10 @@
                     class="difficulty"
                     class:selected={selectedDifficulty === difficulty}
                     role="presentation"
-                    on:click={() => {
+                    on:click={async () => {
                         selectedDifficulty = difficulty;
+                        $page.url.searchParams.set('diff', difficulty);
+                        await goto($page.url, { replaceState: true });
                     }}
                     style={`background-color:${color.difficulty[difficulty]};`}
                 >

--- a/src/routes/(main)/song/[songNo=songNo]/+page.server.ts
+++ b/src/routes/(main)/song/[songNo=songNo]/+page.server.ts
@@ -1,7 +1,16 @@
 import { songDBController } from '$lib/module/common/song/song.server';
+import type { Difficulty } from '$lib/module/common/song/types.js';
+import { redirect } from '@sveltejs/kit';
 
-export async function load({ params }) {
+export async function load({ params, url }) {
+    const song = await songDBController.getSongBySongNo(params.songNo)
+    const diff = (url.searchParams.get('diff') ?? 'oni') as Difficulty
+
+    if (!song?.courses?.[diff]) {
+        redirect(303, `/song/${params.songNo}?diff=oni`)
+    }
+
     return {
-        song: await songDBController.getSongBySongNo(params.songNo)
+        song
     }
 }

--- a/src/routes/(main)/song/[songNo=songNo]/+page.svelte
+++ b/src/routes/(main)/song/[songNo=songNo]/+page.svelte
@@ -24,8 +24,7 @@
     let diff: Difficulty = "oni";
     $: {
         let diffParam = $page.url.searchParams.get('diff') as Difficulty;
-        if (!DIFFICULTY.includes(diffParam)) diff = "oni";
-        else diff = diffParam;
+        diff = song?.courses?.[diffParam] ? diffParam : "oni";
     }
 </script>
 

--- a/src/routes/(main)/song/[songNo=songNo]/+page.svelte
+++ b/src/routes/(main)/song/[songNo=songNo]/+page.svelte
@@ -9,6 +9,9 @@
     import AddSongButton from "$lib/components/page/song/AddSongButton.svelte";
     import PageTitle from "$lib/components/common/PageTitle.svelte";
     import { getI18N, getLang } from "$lib/module/common/i18n/i18n.js";
+    import { page } from "$app/stores";
+    import { DIFFICULTY } from "$lib/module/common/song/const.js";
+    import type { Difficulty } from "$lib/module/common/song/types.js";
 
     export let data;
     const song = data.song;
@@ -17,6 +20,13 @@
     const lang = getLang();
     $: i18n = getI18N('/song/[songNo]', $lang);
     $: titleI18n = getI18N('other', $lang).title['/song/[songNo]'];
+
+    let diff: Difficulty = "oni";
+    $: {
+        let diffParam = $page.url.searchParams.get('diff') as Difficulty;
+        if (!DIFFICULTY.includes(diffParam)) diff = "oni";
+        else diff = diffParam;
+    }
 </script>
 
 {#if song}
@@ -43,7 +53,7 @@
             addedDate={song.addedDate}
         />
     </div>
-    <CourseContainer courses={song.courses} />
+    <CourseContainer courses={song.courses} selectedDifficulty={diff} />
 {:else}
     <PageTitle title={titleI18n}/>
     {i18n.noSong}


### PR DESCRIPTION
기능:
- SearchParam에 있는 diff 기준으로 곡 정보를 보여줌 (현재는 oni로 고정)
- 서열표, 단위도장 에서 알맞는 난이도를 바로 보여줌

논의점:
- key를 diff로 하기 vs difficulty로 하기
- url이 바뀌어서 (replace) `/api/user` 가 불필요하게 호출 됨
